### PR TITLE
Add docker compose file for MySQL 8.4 GR configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ The below steps show how to setup [MySQL Group Replication](https://dev.mysql.co
 ### [Setting up MySQL Group replication with Docker Compose](https://medium.com/gitconnected/setting-up-mysql-group-replication-with-docker-compose-7639347545a2)
 
 ***P.S.** Take a look at this [tutorial](https://medium.com/@wagnerjfr/setting-up-mysql-group-replication-with-mysql-docker-images-f5eedd44fa2b) and check how to setup MySQL Group Replication with Docker containers.*
+
+## Simple usage
+
+```
+$ docker compose up                         # start latest 8.0 GR cluster
+$ docker compose -f docker-compose84.yml up # start latest 8.4 GR cluster
+```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The below steps show how to setup [MySQL Group Replication](https://dev.mysql.co
 ## Simple usage
 
 ```
-$ docker compose up                         # start latest 8.0 GR cluster
-$ docker compose -f docker-compose84.yml up # start latest 8.4 GR cluster
+$ docker compose up                           # start 8.0 GR cluster (using latest version available)
+$ docker compose down                         # stop 8.0 GR cluster
+$ docker compose -f docker-compose84.yml up   # start 8.4 GR cluster (using latest version available)
+$ docker compose -f docker-compose84.yml down # stop 8.4 GR cluster
 ```

--- a/docker-compose84.yml
+++ b/docker-compose84.yml
@@ -1,9 +1,7 @@
-version: '3.5'
-
 services:
 
   node1:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: node1
     hostname: node1
     ports:
@@ -15,12 +13,9 @@ services:
       "--server-id=1",
       "--log-bin=mysql-bin-1.log",
       "--enforce-gtid-consistency=ON",
-      "--log-slave-updates=ON",
+      "--log-replica-updates=ON",
       "--gtid-mode=ON",
-      "--transaction-write-set-extraction=XXHASH64",
       "--binlog-checksum=NONE",
-      "--master-info-repository=TABLE",
-      "--relay-log-info-repository=TABLE",
       "--plugin-load=group_replication.so",
       "--relay-log-recovery=ON",
       "--loose-group-replication-start-on-boot=OFF",
@@ -35,7 +30,7 @@ services:
       retries: 20
 
   node2:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: node2
     hostname: node2
     ports:
@@ -47,12 +42,9 @@ services:
       "--server-id=1",
       "--log-bin=mysql-bin-1.log",
       "--enforce-gtid-consistency=ON",
-      "--log-slave-updates=ON",
+      "--log-replica-updates=ON",
       "--gtid-mode=ON",
-      "--transaction-write-set-extraction=XXHASH64",
       "--binlog-checksum=NONE",
-      "--master-info-repository=TABLE",
-      "--relay-log-info-repository=TABLE",
       "--plugin-load=group_replication.so",
       "--relay-log-recovery=ON",
       "--loose-group-replication-start-on-boot=OFF",
@@ -67,7 +59,7 @@ services:
       retries: 20
 
   node3:
-    image: mysql:8.0
+    image: mysql:8.4
     container_name: node3
     hostname: node3
     ports:
@@ -79,12 +71,9 @@ services:
       "--server-id=1",
       "--log-bin=mysql-bin-1.log",
       "--enforce-gtid-consistency=ON",
-      "--log-slave-updates=ON",
+      "--log-replica-updates=ON",
       "--gtid-mode=ON",
-      "--transaction-write-set-extraction=XXHASH64",
       "--binlog-checksum=NONE",
-      "--master-info-repository=TABLE",
-      "--relay-log-info-repository=TABLE",
       "--plugin-load=group_replication.so",
       "--relay-log-recovery=ON",
       "--loose-group-replication-start-on-boot=OFF",


### PR DESCRIPTION
With MySQL 8.0 close to being end of life (April 2026) and also because Oracle has a new 8.4 LTS version it seems useful to provide a docker compose file which works against the latest LTS version.

This tiny patch does that.

- add to the README.md an extremely brief usage line
- modify image used to follow the format usage by Oracle: `mysql:A.B`, e.g. `mysql:8.0`, `mysql:8.4`
- in the `docker-compose84.yml` file remove some settings which are no longer valid.